### PR TITLE
catch type conversion error and prevent infinite loop

### DIFF
--- a/Sources/SwiftSerial.swift
+++ b/Sources/SwiftSerial.swift
@@ -210,6 +210,7 @@ public enum PortError: Int32, Error {
     case mustBeOpen
     case stringsMustBeUTF8
     case unableToConvertByteToCharacter
+    case deviceNotConnected
 }
 
 public class SerialPort {
@@ -371,7 +372,13 @@ extension SerialPort {
         guard let fileDescriptor = fileDescriptor else {
             throw PortError.mustBeOpen
         }
-
+        
+        var s: stat = stat()
+        fstat(fileDescriptor, &s)
+        if s.st_nlink != 1 {
+            throw PortError.deviceNotConnected
+        }
+        
         let bytesRead = read(fileDescriptor, buffer, size)
         return bytesRead
     }

--- a/Sources/SwiftSerial.swift
+++ b/Sources/SwiftSerial.swift
@@ -209,6 +209,7 @@ public enum PortError: Int32, Error {
     case mustReceiveOrTransmit
     case mustBeOpen
     case stringsMustBeUTF8
+    case unableToConvertByteToCharacter
 }
 
 public class SerialPort {
@@ -424,6 +425,9 @@ extension SerialPort {
             let bytesRead = try readBytes(into: buffer, size: 1)
 
             if bytesRead > 0 {
+                if ( buffer[0] > 127) {
+                    throw PortError.unableToConvertByteToCharacter
+                }
                 let character = CChar(buffer[0])
                 
                 if character == terminator {


### PR DESCRIPTION
Because CChar is a typealias for Int8 it only can handle values up to 127.
When reading from the buffer and converting the value at buffer[0] to CChar it is possible that values larger than 127 occur.
This leads to crashes.
To prevent this I created PortError.unableToConvertByteToCharacter that is thrown for values larger than 127.