### PR TITLE
Swift V5 Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,6 @@ let package = Package(
                 path: "Sources"),
     ],
     swiftLanguageVersions: [
-        .v5
+        .v4
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftSerial"
+    name: "SwiftSerial",
+    
+    products: [
+        .library(name: "SwiftSerial", targets: ["SwiftSerial"])
+    ],
+    targets: [
+        .target(name: "SwiftSerial",
+                path: "Sources"),
+    ],
+    swiftLanguageVersions: [
+        .v5
+    ]
 )


### PR DESCRIPTION
I have never done this before so if I have missed something please tell me! ;-) 

Repo Package.swift modified to support Swift Package Manager for Swift 5.  

Change SPM command to:


> Add SwiftSerial as a dependency to your project by editing the Package.swift file.

```swift
// swift-tools-version:5.0
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "MyApp",
    dependencies: [
        .package(
            url: "https://github.com/MotivDev/SwiftSerial", .upToNextMajor(from:"0.1.0")
        ),
...
```