### PR TITLE
Disabled input processing

### DIFF
--- a/Sources/SwiftSerial.swift
+++ b/Sources/SwiftSerial.swift
@@ -299,6 +299,9 @@ public class SerialPort {
         settings.c_cflag &= ~tcflag_t(CSIZE)
         settings.c_cflag |= dataBitsSize.flagValue
 
+        //Disable input mapping of CR to NL, mapping of NL into CR, and ignoring CR
+        settings.c_iflag &= ~tcflag_t(ICRNL | INLCR | IGNCR)
+
         // Set hardware flow control flag
     #if os(Linux)
         if useHardwareFlowControl {


### PR DESCRIPTION
Hi

We had an issue on Linux that some input characters were converted on the input side, like 0x0D -> 0x0A, which was a problem for us as we are working with a binary protocol. So we had to ensure to disable all input processing to avoid problem with currupt packages and wrong checksums. 

So please see the suggested change and judge if it can be useful to you. Otherwise we would suggest adding a "processInput" flag and make that disable or enable this feature so that it is clear what is happening.

But thanks for a otherwise very functional library :) 