### PR TITLE
Background read

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "SwiftSerial",
+	name: "SwiftSerial",
+	platforms: [
+		.macOS(.v10_15),
+	],
 	products: [
 		.library(name: "SwiftSerial", targets: ["SwiftSerial"]),
 	],

--- a/Sources/SwiftSerial.swift
+++ b/Sources/SwiftSerial.swift
@@ -222,6 +222,7 @@ public class SerialPort {
             }
         }
         pollSource.resume()
+        self.pollSource = pollSource
         self.readDataStream = stream
     }
 

--- a/Sources/SwiftSerial.swift
+++ b/Sources/SwiftSerial.swift
@@ -221,6 +221,7 @@ public class SerialPort {
                 continuation.finish()
             }
         }
+        pollSource.resume()
         self.readDataStream = stream
     }
 

--- a/Sources/SwiftSerial.swift
+++ b/Sources/SwiftSerial.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-#if os(Linux)
 public enum BaudRate {
     case baud0
     case baud50
@@ -21,6 +20,7 @@ public enum BaudRate {
     case baud57600
     case baud115200
     case baud230400
+    #if os(Linux)
     case baud460800
     case baud500000
     case baud576000
@@ -32,6 +32,7 @@ public enum BaudRate {
     case baud2500000
     case baud3500000
     case baud4000000
+    #endif
 
     var speedValue: speed_t {
         switch self {
@@ -73,6 +74,7 @@ public enum BaudRate {
             return speed_t(B115200)
         case .baud230400:
             return speed_t(B230400)
+        #if os(Linux)
         case .baud460800:
             return speed_t(B460800)
         case .baud500000:
@@ -95,75 +97,10 @@ public enum BaudRate {
             return speed_t(B3500000)
         case .baud4000000:
             return speed_t(B4000000)
+        #endif
         }
     }
 }
-#elseif os(OSX)
-public enum BaudRate {
-    case baud0
-    case baud50
-    case baud75
-    case baud110
-    case baud134
-    case baud150
-    case baud200
-    case baud300
-    case baud600
-    case baud1200
-    case baud1800
-    case baud2400
-    case baud4800
-    case baud9600
-    case baud19200
-    case baud38400
-    case baud57600
-    case baud115200
-    case baud230400
-
-    var speedValue: speed_t {
-        switch self {
-        case .baud0:
-            return speed_t(B0)
-        case .baud50:
-            return speed_t(B50)
-        case .baud75:
-            return speed_t(B75)
-        case .baud110:
-            return speed_t(B110)
-        case .baud134:
-            return speed_t(B134)
-        case .baud150:
-            return speed_t(B150)
-        case .baud200:
-            return speed_t(B200)
-        case .baud300:
-            return speed_t(B300)
-        case .baud600:
-            return speed_t(B600)
-        case .baud1200:
-            return speed_t(B1200)
-        case .baud1800:
-            return speed_t(B1800)
-        case .baud2400:
-            return speed_t(B2400)
-        case .baud4800:
-            return speed_t(B4800)
-        case .baud9600:
-            return speed_t(B9600)
-        case .baud19200:
-            return speed_t(B19200)
-        case .baud38400:
-            return speed_t(B38400)
-        case .baud57600:
-            return speed_t(B57600)
-        case .baud115200:
-            return speed_t(B115200)
-        case .baud230400:
-            return speed_t(B230400)
-        }
-    }
-}
-#endif
 
 public enum DataBitsSize {
     case bits5


### PR DESCRIPTION
Reduces a bit of redundancy in BaudRate, but more importantly uses AsyncStream to allow for streaming from the serial port.